### PR TITLE
fix build errors on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
-cmake_minimum_required (VERSION 3.13)
+cmake_minimum_required (VERSION 3.15)
+cmake_policy(SET CMP0091 NEW)  # MSVC runtime library flags are selected by an abstraction
 project(albc)
+
+add_compile_options("$<$<C_COMPILER_ID:MSVC>:/utf-8>")
+add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/out)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/out)
@@ -10,3 +14,8 @@ set(LLVM_ENABLE_EH ON)
 
 add_subdirectory(src)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/test DESTINATION ${CMAKE_BINARY_DIR}/out)
+
+# remove manually added MSVC runtime library flags
+if(MSVC)
+    include(UnfuckMSVC.cmake)
+endif()

--- a/UnfuckMSVC.cmake
+++ b/UnfuckMSVC.cmake
@@ -1,0 +1,38 @@
+function(get_all_targets var)
+    set(targets)
+    get_all_targets_recursive(targets ${CMAKE_CURRENT_SOURCE_DIR})
+    set(${var} ${targets} PARENT_SCOPE)
+endfunction()
+
+macro(get_all_targets_recursive targets dir)
+    get_property(subdirectories DIRECTORY ${dir} PROPERTY SUBDIRECTORIES)
+    foreach(subdir ${subdirectories})
+        get_all_targets_recursive(${targets} ${subdir})
+    endforeach()
+
+    get_property(current_targets DIRECTORY ${dir} PROPERTY BUILDSYSTEM_TARGETS)
+    list(APPEND ${targets} ${current_targets})
+endmacro()
+
+macro(unfuck_msvc_runtime_compile_options target property_name)
+    get_target_property(cflags ${target} ${property_name})
+    if(NOT "${cflags}" STREQUAL "cflags-NOTFOUND")
+        message(DEBUG "old ${property_name}: ${cflags}")
+        list(FILTER cflags EXCLUDE REGEX "/M[DT](d|$<$<CONFIG:Debug>:d>)?")
+        message(DEBUG "new ${property_name}: ${cflags}")
+        set_target_properties(${target} PROPERTIES ${property_name} "${cflags}")
+    endif()
+endmacro()
+
+macro(unfuck_msvc_runtime target)
+    message(DEBUG "unfucking ${target} for MSVC")
+    unfuck_msvc_runtime_compile_options(${target} COMPILE_OPTIONS)
+    unfuck_msvc_runtime_compile_options(${target} INTERFACE_COMPILE_OPTIONS)
+endmacro()
+
+message(STATUS "Unfucking MSVC runtime flags for all targets")
+get_all_targets(all_targets)
+
+foreach(target ${all_targets})
+    unfuck_msvc_runtime(${target})
+endforeach()


### PR DESCRIPTION
* remove manually set MSVC runtime library flags in third-party
  libraries
  - use CMAKE_MSVC_RUNTIME_LIBRARY to specify runtime library type
* set source/target encoding to UTF-8

Test:
```console
> "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
...
> cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded ..
...
> cmake --build . --target albc
...
> dumpbin /dependents out\albc.dll
Microsoft (R) COFF/PE Dumper Version 14.31.31104.0
Copyright (C) Microsoft Corporation.  All rights reserved.


Dump of file out\albc.dll

File Type: DLL

  Image has the following dependencies:

    KERNEL32.dll

  Summary

        A000 .data
       16000 .pdata
       69000 .rdata
        3000 .reloc
        1000 .rsrc
      2F2000 .text
        1000 _RDATA
```

```console
> "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
...
> cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL ..
...
> cmake --build . --target albc
...
> dumpbin /dependents out\albc.dll
Microsoft (R) COFF/PE Dumper Version 14.31.31104.0
Copyright (C) Microsoft Corporation.  All rights reserved.


Dump of file out\albc.dll

File Type: DLL

  Image has the following dependencies:

    KERNEL32.dll
    MSVCP140.dll
    VCRUNTIME140.dll
    VCRUNTIME140_1.dll
    api-ms-win-crt-runtime-l1-1-0.dll
    api-ms-win-crt-string-l1-1-0.dll
    api-ms-win-crt-math-l1-1-0.dll
    api-ms-win-crt-heap-l1-1-0.dll
    api-ms-win-crt-stdio-l1-1-0.dll
    api-ms-win-crt-filesystem-l1-1-0.dll
    api-ms-win-crt-time-l1-1-0.dll
    api-ms-win-crt-convert-l1-1-0.dll
    api-ms-win-crt-locale-l1-1-0.dll
    api-ms-win-crt-environment-l1-1-0.dll

  Summary

        7000 .data
       13000 .pdata
       56000 .rdata
        2000 .reloc
        1000 .rsrc
      2A7000 .text
        1000 _RDATA
```